### PR TITLE
Changing image path once again

### DIFF
--- a/skeleton/options.php
+++ b/skeleton/options.php
@@ -28,21 +28,18 @@ function optionsframework_option_name() {
  *  
  */
 
-function optionsframework_options() {
-	
-	// Background Defaults
-	
-	$body_background_defaults = array(
-	'color' => '#fcfcfc',
-	'image' => site_url('wp-content/themes/skeleton/images/border_top.png'),
-	'repeat' => 'repeat-x',
-	'position' => 'top center',
-	'attachment'=>'fixed');
-	
-	
+function optionsframework_options() {	
 		
 	// If using image radio buttons, define a directory path
 	$imagepath =  get_bloginfo('template_directory') . '/images/';
+
+	// Background Defaults	
+	$body_background_defaults = array(
+	'color' => '#fcfcfc',
+	'image' => $imagepath.'border_top.png',
+	'repeat' => 'repeat-x',
+	'position' => 'top center',
+	'attachment'=>'fixed');
 		
 	$options = array();
 						


### PR DESCRIPTION
Not sure why I didn't see this with the first pull request I submitted to you for this, but it really shouldn't be hard coded to wp-content/themes/...... 
Changing to use the variable $imagepath instead. 
