### PR TITLE
Fix include path for of-medialibrary-uploader.js in options-medialibrary-uploader.php

### DIFF
--- a/skeleton/admin/options-medialibrary-uploader.php
+++ b/skeleton/admin/options-medialibrary-uploader.php
@@ -70,7 +70,7 @@ if ( ! function_exists( 'optionsframework_mlu_js' ) ) {
 	function optionsframework_mlu_js () {
 	
 		// Registers custom scripts for the Media Library AJAX uploader.
-		wp_register_script( 'of-medialibrary-uploader', OPTIONS_FRAMEWORK_DIRECTORY .'js/of-medialibrary-uploader.js', array( 'jquery', 'thickbox' ) );
+		wp_register_script( 'of-medialibrary-uploader', OPTIONS_FRAMEWORK_URL .'js/of-medialibrary-uploader.js', array( 'jquery', 'thickbox' ) );
 		wp_enqueue_script( 'of-medialibrary-uploader' );
 		wp_enqueue_script( 'media-upload' );
 	}


### PR DESCRIPTION
The optionsframework_mlu_js function now uses OPTIONS_FRAMEWORK_URL to register the of-medialibrary-uploader.js script instead of OPTIONS_FRAMEWORK_DIRECTORY.
