### PR TITLE
The medialibrary uploader was not working

### DIFF
--- a/skeleton/admin/options-medialibrary-uploader.php
+++ b/skeleton/admin/options-medialibrary-uploader.php
@@ -70,7 +70,7 @@ if ( ! function_exists( 'optionsframework_mlu_js' ) ) {
 	function optionsframework_mlu_js () {
 	
 		// Registers custom scripts for the Media Library AJAX uploader.
-		wp_register_script( 'of-medialibrary-uploader', OPTIONS_FRAMEWORK_DIRECTORY .'js/of-medialibrary-uploader.js', array( 'jquery', 'thickbox' ) );
+		wp_register_script( 'of-medialibrary-uploader', OPTIONS_FRAMEWORK_URL .'js/of-medialibrary-uploader.js', array( 'jquery', 'thickbox' ) );
 		wp_enqueue_script( 'of-medialibrary-uploader' );
 		wp_enqueue_script( 'media-upload' );
 	}


### PR DESCRIPTION
It was set as

wp_register_script( 'of-medialibrary-uploader', OPTIONS_FRAMEWORK_DIRECTORY .'js/of-medialibrary-uploader.js', array( 'jquery', 'thickbox' ) );

instead of what it should be:

wp_register_script( 'of-medialibrary-uploader', OPTIONS_FRAMEWORK_URL .'js/of-medialibrary-uploader.js', array( 'jquery', 'thickbox' ) );

Which in turn caused the theme options on dashboard to now allow uploading images.
